### PR TITLE
CONFIG: Update NuGet dependencies and modernise ADotNet build/PR workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       prefix: "CONFIG"
     labels:
       - "dependencies"
+    ignore:
+        - dependency-name: "FluentAssertions"
+          versions: ["8.x", "9.x", "10.x", "*"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
     - synchronize
     - reopened
     - closed
-    branches:
-    - main
 env:
   MESHCONFIGURATION__URL: ${{ secrets.MESHCONFIGURATION__URL }}
   MESHCONFIGURATION__MAILBOXID: ${{ secrets.MESHCONFIGURATION__MAILBOXID }}
@@ -25,9 +23,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Check Out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Dot Net Version
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
     - name: Restore
@@ -55,7 +53,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.PAT_FOR_TAGGING }}
     - name: Configure Git
@@ -128,9 +126,9 @@ jobs:
     if: needs.add_tag.result == 'success'
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup .Net
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
     - name: Restore

--- a/.github/workflows/prLinter.yml
+++ b/.github/workflows/prLinter.yml
@@ -11,11 +11,12 @@ on:
     - main
 jobs:
   label:
-    name: Add Label(s)
+    name: Label
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
     - name: Apply Label
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: >-
@@ -84,16 +85,17 @@ jobs:
           }
     permissions:
       contents: read
+      issues: write
       pull-requests: write
   requireIssueOrTask:
     name: Require Issue Or Task Association
     runs-on: ubuntu-latest
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Get PR Information
       id: get_pr_info
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         script: >2-
               const pr = await github.rest.pulls.get({
@@ -110,7 +112,7 @@ jobs:
               console.log(`PR Body: ${prBody}`);
     - name: Check For Associated Issues Or Tasks
       id: check_for_issues_or_tasks
-      if: ${{ steps.get_pr_info.outputs.prOwner != 'dependabot[bot]' }}
+      if: ${{ !contains(',dependabot[bot],', format(',{0},', steps.get_pr_info.outputs.prOwner)) }}
       env:
         PR_BODY: ${{ steps.get_pr_info.outputs.description }}
       run: >2-
@@ -131,3 +133,42 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+  setAuthorAsPrAssignee:
+    name: Set Author As PR Assignee
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+    - name: Set Author As PR Assignee
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: >
+          const pr = context.payload.pull_request;
+
+          if (!pr) {
+            console.log('No pull request context available.');
+            return;
+          }
+
+
+          const author = pr.user.login;
+
+          if (author.endsWith('[bot]')) {
+            console.log(`Skipping bot author: ${author}`);
+            return;
+          }
+
+
+          console.log(`Assigning PR to author: ${author}`);
+
+
+          await github.rest.issues.addAssignees({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+            assignees: [author]
+          });
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write

--- a/NEL.MESH.Infrastructure/NEL.MESH.Infrastructure.csproj
+++ b/NEL.MESH.Infrastructure/NEL.MESH.Infrastructure.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ADotNet" Version="4.3.0" />
+		<PackageReference Include="ADotNet" Version="5.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/NEL.MESH.Infrastructure/Services/ScriptGenerationService.cs
+++ b/NEL.MESH.Infrastructure/Services/ScriptGenerationService.cs
@@ -5,7 +5,7 @@
 using ADotNet.Clients;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV3s;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV5s;
 
 namespace NEL.MESH.Infrastructure.Services
 {
@@ -28,8 +28,7 @@ namespace NEL.MESH.Infrastructure.Services
 
                     PullRequest = new PullRequestEvent
                     {
-                        Types = ["opened", "synchronize", "reopened", "closed"],
-                        Branches = [branchName]
+                        Types = ["opened", "synchronize", "reopened", "closed"]
                     }
                 },
 
@@ -55,16 +54,16 @@ namespace NEL.MESH.Infrastructure.Services
 
                             Steps = new List<GithubTask>
                             {
-                                new CheckoutTaskV3
+                                new CheckoutTaskV5
                                 {
                                     Name = "Check Out"
                                 },
 
-                                new SetupDotNetTaskV3
+                                new SetupDotNetTaskV5
                                 {
                                     Name = "Setup Dot Net Version",
 
-                                    With = new TargetDotNetVersionV3
+                                    With = new TargetDotNetVersionV5
                                     {
                                         DotNetVersion = dotNetVersion
                                     }
@@ -100,7 +99,7 @@ namespace NEL.MESH.Infrastructure.Services
                     },
                     {
                         "add_tag",
-                        new TagJob(
+                        new TagJobV2(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "build",
                             projectRelativePath: $"{projectName}/{projectName}.csproj",
@@ -112,7 +111,7 @@ namespace NEL.MESH.Infrastructure.Services
                     },
                     {
                         "publish",
-                        new PublishJobV2(
+                        new PublishJobV4(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "add_tag",
                             dotNetVersion: dotNetVersion,
@@ -156,16 +155,23 @@ namespace NEL.MESH.Infrastructure.Services
                 {
                     {
                         "label",
-                        new LabelJobV2(runsOn: BuildMachines.UbuntuLatest)
+                        new LabelJobV3(runsOn: BuildMachines.UbuntuLatest)
                         {
-                            Name = "Add Label(s)",
+                            Name = "Label"
                         }
                     },
                     {
                         "requireIssueOrTask",
-                        new RequireIssueOrTaskJob()
+                        new RequireIssueOrTaskJobV2(excludedAuthors: "dependabot[bot]")
                         {
                             Name = "Require Issue Or Task Association",
+                        }
+                    },
+                    {
+                        "setAuthorAsPrAssignee",
+                        new SetAuthorAsPrAssigneeJobV2(runsOn: BuildMachines.UbuntuLatest)
+                        {
+                            Name = "Set Author As PR Assignee",
                         }
                     },
                 }

--- a/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
+++ b/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />

--- a/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
+++ b/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
+++ b/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
-		<PackageReference Include="WireMock.Net" Version="2.6.0" />
+		<PackageReference Include="WireMock.Net" Version="2.11.0" />
 		<PackageReference Include="Xeption" Version="2.9.0" />
 		<PackageReference Include="xunit.analyzers" Version="1.27.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
+++ b/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="WireMock.Net" Version="2.6.0" />

--- a/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
+++ b/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
+++ b/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />

--- a/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
+++ b/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
+++ b/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
+++ b/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />

--- a/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
+++ b/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
+++ b/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />

--- a/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
+++ b/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
+++ b/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NEL.MESH.UI/NEL.MESH.UI.csproj
+++ b/NEL.MESH.UI/NEL.MESH.UI.csproj
@@ -13,7 +13,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 	</ItemGroup>
 

--- a/NEL.MESH.UI/NEL.MESH.UI.csproj
+++ b/NEL.MESH.UI/NEL.MESH.UI.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NEL.MESH.UI/NEL.MESH.UI.csproj
+++ b/NEL.MESH.UI/NEL.MESH.UI.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />

--- a/NEL.MESH.UI/NEL.MESH.UI.csproj
+++ b/NEL.MESH.UI/NEL.MESH.UI.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 	</ItemGroup>

--- a/NEL.MESH/NEL.MESH.csproj
+++ b/NEL.MESH/NEL.MESH.csproj
@@ -51,7 +51,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NEL.MESH/NEL.MESH.csproj
+++ b/NEL.MESH/NEL.MESH.csproj
@@ -52,7 +52,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Xeption" Version="2.9.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
Brings MeshClient up to the .NET 10 modernisation standard.

closes [AB#29755](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29755)

### Dependency updates (CONFIG)
- Microsoft.Extensions.DependencyInjection 10.0.8 -> 10.0.9
- Microsoft.Extensions.Configuration 10.0.8 -> 10.0.9
- Microsoft.Extensions.Configuration.Json 10.0.8 -> 10.0.9
- Microsoft.Extensions.Configuration.Binder 10.0.8 -> 10.0.9
- Microsoft.Extensions.Configuration.EnvironmentVariables 10.0.8 -> 10.0.9
- Microsoft.Extensions.Hosting 10.0.8 -> 10.0.9
- Microsoft.NET.Test.Sdk 18.5.1 -> 18.7.0
- WireMock.Net 2.6.0 -> 2.11.0
- ADotNet 4.3.0 -> 5.0.0
- dependabot: add FluentAssertions ignore rule (locked at [7.2.2])

### Workflow modernisation (CODE RUB)
- ADotNet components -> latest (CheckoutTaskV5 / SetupDotNetTaskV5 / LabelJobV3 / TagJobV2 / PublishJobV4); build.yml now on Node-24 actions (checkout@v5, setup-dotnet@v5, github-script@v8)
- prLinter.yml: added Set Author As PR Assignee; RequireIssueOrTask -> V2 (excludes dependabot[bot]); Label -> V3
- Dropped the PR branch-filter from build.yml (kept the filter on prLinter, per Christo)

### Validation
- Build: 0 errors, 0 obsolete warnings
- Tests: 310 pass (292 Unit + 8 Integration + 10 Acceptance)
- Workflows regenerated from the Infrastructure project (idempotent, not hand-edited)

### Note for reviewer
- WireMock.Net 2.11.0 (latest) reduces the pre-existing Scriban.Signed vuln from **High -> Moderate** (test-only transitive, not shipped). Fully clearing it would require pinning the transitive (Rule #9 sign-off) - left as-is for a decision.
