### PR TITLE
CONFIG: Update NuGet dependencies and ADotNet 5.1.0 regen

### DIFF
--- a/.github/workflows/prLinter.yml
+++ b/.github/workflows/prLinter.yml
@@ -22,27 +22,84 @@ jobs:
         script: >-
           const prefixes = [
             'INFRA:',
+            'MINOR INFRA:',
+            'MEDIUM INFRA:',
+            'MAJOR INFRA:',
             'PROVISIONS:',
             'RELEASES:',
             'DATA:',
+            'MINOR DATA:',
+            'MEDIUM DATA:',
+            'MAJOR DATA:',
             'BROKERS:',
+            'MINOR BROKERS:',
+            'MEDIUM BROKERS:',
+            'MAJOR BROKERS:',
             'FOUNDATIONS:',
+            'MINOR FOUNDATIONS:',
+            'MEDIUM FOUNDATIONS:',
+            'MAJOR FOUNDATIONS:',
             'PROCESSINGS:',
+            'MINOR PROCESSINGS:',
+            'MEDIUM PROCESSINGS:',
+            'MAJOR PROCESSINGS:',
             'ORCHESTRATIONS:',
+            'MINOR ORCHESTRATIONS:',
+            'MEDIUM ORCHESTRATIONS:',
+            'MAJOR ORCHESTRATIONS:',
             'COORDINATIONS:',
+            'MINOR COORDINATIONS:',
+            'MEDIUM COORDINATIONS:',
+            'MAJOR COORDINATIONS:',
             'MANAGEMENTS:',
+            'MINOR MANAGEMENTS:',
+            'MEDIUM MANAGEMENTS:',
+            'MAJOR MANAGEMENTS:',
             'AGGREGATIONS:',
+            'MINOR AGGREGATIONS:',
+            'MEDIUM AGGREGATIONS:',
+            'MAJOR AGGREGATIONS:',
             'CONTROLLERS:',
+            'MINOR CONTROLLERS:',
+            'MEDIUM CONTROLLERS:',
+            'MAJOR CONTROLLERS:',
             'CLIENTS:',
+            'MINOR CLIENTS:',
+            'MEDIUM CLIENTS:',
+            'MAJOR CLIENTS:',
             'EXPOSERS:',
+            'MINOR EXPOSERS:',
+            'MEDIUM EXPOSERS:',
+            'MAJOR EXPOSERS:',
             'PROVIDERS:',
             'BASE:',
+            'MINOR BASE:',
+            'MEDIUM BASE:',
+            'MAJOR BASE:',
             'COMPONENTS:',
+            'MINOR COMPONENTS:',
+            'MEDIUM COMPONENTS:',
+            'MAJOR COMPONENTS:',
             'VIEWS:',
+            'MINOR VIEWS:',
+            'MEDIUM VIEWS:',
+            'MAJOR VIEWS:',
             'PAGES:',
+            'MINOR PAGES:',
+            'MEDIUM PAGES:',
+            'MAJOR PAGES:',
             'ACCEPTANCE:',
+            'MINOR ACCEPTANCE:',
+            'MEDIUM ACCEPTANCE:',
+            'MAJOR ACCEPTANCE:',
             'INTEGRATIONS:',
+            'MINOR INTEGRATIONS:',
+            'MEDIUM INTEGRATIONS:',
+            'MAJOR INTEGRATIONS:',
             'CODE RUB:',
+            'MINOR CODE RUB:',
+            'MEDIUM CODE RUB:',
+            'MAJOR CODE RUB:',
             'MINOR FIX:',
             'MEDIUM FIX:',
             'MAJOR FIX:',
@@ -50,7 +107,23 @@ jobs:
             'CONFIG:',
             'STANDARD:',
             'DESIGN:',
-            'BUSINESS:'
+            'MINOR DESIGN:',
+            'MEDIUM DESIGN:',
+            'MAJOR DESIGN:',
+            'BUSINESS:',
+            'MIGRATIONS:',
+            'PLANNING:',
+            'MINOR PLANNING:',
+            'MAJOR PLANNING:',
+            'MENTORSHIP:',
+            'MINOR MENTORSHIP:',
+            'MAJOR MENTORSHIP:',
+            'DISCUSSION:',
+            'MINOR DISCUSSION:',
+            'MAJOR DISCUSSION:',
+            'IMPORTS:',
+            'REVIEWS:',
+            'STATUS:'
           ];
 
 
@@ -162,12 +235,16 @@ jobs:
           console.log(`Assigning PR to author: ${author}`);
 
 
-          await github.rest.issues.addAssignees({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: pr.number,
-            assignees: [author]
-          });
+          try {
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [author]
+            });
+          } catch (error) {
+            console.log(`Unable to assign ${author} as PR assignee: ${error.message}`);
+          }
     permissions:
       contents: read
       issues: write

--- a/NEL.MESH.Infrastructure/NEL.MESH.Infrastructure.csproj
+++ b/NEL.MESH.Infrastructure/NEL.MESH.Infrastructure.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ADotNet" Version="5.0.0" />
+		<PackageReference Include="ADotNet" Version="5.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
+++ b/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="WireMock.Net" Version="2.11.0" />

--- a/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
+++ b/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
@@ -12,8 +12,8 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
+++ b/NEL.MESH.Tests.Acceptance/NEL.MESH.Tests.Acceptance.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
-		<PackageReference Include="WireMock.Net" Version="2.11.0" />
+		<PackageReference Include="WireMock.Net" Version="2.13.0" />
 		<PackageReference Include="Xeption" Version="2.9.0" />
 		<PackageReference Include="xunit.analyzers" Version="1.27.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
+++ b/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
@@ -16,8 +16,8 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
+++ b/NEL.MESH.Tests.Integration.Witness/NEL.MESH.Tests.Integration.Witness.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
+++ b/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
@@ -16,8 +16,8 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
+++ b/NEL.MESH.Tests.Integration/NEL.MESH.Tests.Integration.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
+++ b/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
+++ b/NEL.MESH.Tests.Unit/NEL.MESH.Tests.Unit.csproj
@@ -12,8 +12,8 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NEL.MESH.UI/NEL.MESH.UI.csproj
+++ b/NEL.MESH.UI/NEL.MESH.UI.csproj
@@ -11,10 +11,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NEL.MESH/NEL.MESH.csproj
+++ b/NEL.MESH/NEL.MESH.csproj
@@ -51,8 +51,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Xeption" Version="2.9.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
NuGet currency pass for MeshClient - brings every unpinned package to latest stable and completes the ADotNet 5.1.0 rollout (bump + workflow regen). Supersedes dependabot #212/#213/#214 (they auto-close on merge).

closes [AB#29755](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29755)

### Dependency updates (CONFIG, one per commit)
- Microsoft.Extensions family 10.0.9 -> 10.0.10 (Configuration, Json, Binder, EnvironmentVariables, DependencyInjection, Hosting - coupled family, one commit; this is why dependabot's one-at-a-time bumps #214 failed)
- Microsoft.NET.Test.Sdk 18.7.0 -> 18.8.1
- WireMock.Net 2.11.0 -> 2.13.0 (clears the Scriban.Signed moderate transitive vulnerability)
- ADotNet 5.0.0 -> 5.1.0

### Workflow regeneration (CODE RUB)
- prLinter.yml regenerated from NEL.MESH.Infrastructure (run from bin dir, verified idempotent, no stray output): 5.1.0 expanded MINOR/MEDIUM/MAJOR label prefixes + SetAuthorAsPrAssignee try/catch hardening. Generator-produced, not hand-edited.

### Validation (local)
- Build Release: 0 errors (each bump build-gated)
- dotnet list package --vulnerable --include-transitive: none (was 1 moderate via WireMock 2.11.0)
- FluentAssertions remains locked [7.2.2]

### Note for reviewer
Christo's older PRs #152/#154 (May 2025, conflicting) touch some of the same csproj files - left untouched here; worth deciding their fate when he is back.