### PR TITLE
CONFIG: Fix FluentAssertions dependabot ignore to update-types syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
       - "dependencies"
     ignore:
         - dependency-name: "FluentAssertions"
-          versions: ["8.x", "9.x", "10.x", "*"]
+          update-types: ["version-update:semver-major"]


### PR DESCRIPTION
One-line baseline fix: the versions-list ignore form ('8.x','9.x','10.x','*') does not block nuget bumps - dependabot still raised FluentAssertions 8.10.0 PRs (closed with Christo's OK; 8.x is a paid license). Switched to update-types: version-update:semver-major, the form verified working across the nine uplifted repos. The [7.2.2] bracket pin in the csprojs remains the primary lock.

closes [AB#30027](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/30027)